### PR TITLE
fix melee uptime, default to 3.8s max swing speed

### DIFF
--- a/backend/src/analysis/core_analysis.py
+++ b/backend/src/analysis/core_analysis.py
@@ -1173,7 +1173,7 @@ class CoreAbilities(BaseAnalyzer):
 
 class MeleeUptimeAnalyzer(BaseAnalyzer):
     def __init__(
-        self, fight_duration, ignore_windows, max_swing_speed=2500, event_predicate=None
+        self, fight_duration, ignore_windows, max_swing_speed=3800, event_predicate=None
     ):
         self._fight_duration = fight_duration
         self._windows = []

--- a/extensions/src/content.js
+++ b/extensions/src/content.js
@@ -2,7 +2,7 @@ const buttonId = "dk-analyze-btn"
 const iframeId = "dk-analyze-iframe"
 let currentParams = null
 const localIDs = [
-  "aalplhgcljbeccbfkbdfhkfnenfmjhdf",
+  "aeieohnbigjehliffdcpnaegkiekbdlb",
   "dpdollnoobppbpcnfneijbmlkddpfaeg",
   "pjomadfjjobkggnpjjhnfhccjkgmplpj",
 ]

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,2 +1,5 @@
-server: 
+install:
+	yarn install
+
+server: install
 	yarn dev


### PR DESCRIPTION
Closes https://github.com/ryancraigdavis/WCL_DK_Analyzer/issues/7

Decided not to detect 1h vs 2h, would need to hard-code a list of item IDs...