### PR TITLE
fix atramedes deadzone

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -32,8 +32,8 @@ test: venv
 	$(VENV_ACTIVATE) && ${PYTHON} -m pytest
 
 lint: venv
-	$(VENV_ACTIVATE) && ${PYTHON} -m black src/ tests/
-	$(VENV_ACTIVATE) && ${PYTHON} -m flake8 src/ tests/ --max-line-length 150 --statistics --show-source
+	$(VENV_ACTIVATE) && ${PYTHON} -m black src/
+	$(VENV_ACTIVATE) && ${PYTHON} -m flake8 src/ --max-line-length 150 --statistics --show-source
 
 
 lint-check: venv

--- a/backend/src/analysis/core_analysis.py
+++ b/backend/src/analysis/core_analysis.py
@@ -252,6 +252,7 @@ class DeadZoneAnalyzer(BasePreprocessor):
         return [
             Window(window.start, min(window.end, self._fight.duration))
             for window in self._dead_zones
+            if window.start <= self._fight.duration
         ]
 
     def decorate_event(self, event):

--- a/backend/src/analysis/core_analysis.py
+++ b/backend/src/analysis/core_analysis.py
@@ -1,3 +1,4 @@
+import functools
 import itertools
 from collections import defaultdict
 from typing import Optional
@@ -11,7 +12,6 @@ from analysis.base import (
     range_overlap,
 )
 from analysis.items import Trinket, ItemPreprocessor
-from console_table import console
 from report import Fight
 
 
@@ -40,7 +40,9 @@ class DeadZoneAnalyzer(BasePreprocessor):
         self._last_timestamp = 0
         self._checker = {
             "Ascendant Council": self._check_ascendant_council,
-            "Atramedes": self._check_atramedes,
+            "Atramedes": functools.partial(
+                self._check_boss_events_occur, only_melee=True
+            ),
             "Al'Akir": self._check_al_akir,
             "Nefarion's End": self._check_nefarion_mind_control,
             "Loatheb": self._check_loatheb,
@@ -56,10 +58,13 @@ class DeadZoneAnalyzer(BasePreprocessor):
         self._encounter_name = self._fight.encounter.name
         self._is_hard_mode = self._fight.is_hard_mode
 
-    def _check_boss_events_occur(self, event):
+    def _check_boss_events_occur(self, event, only_melee=False):
         if event.get("source_is_boss") or (
             event.get("target_is_boss") and event["type"] == "cast"
         ):
+            if only_melee and event["ability"] not in self.MELEE_ABILITIES:
+                return
+
             if event["timestamp"] - self._last_timestamp > 7000:
                 dead_zone = self.DeadZone(self._last_timestamp, event["timestamp"])
                 self._dead_zones.append(dead_zone)
@@ -163,33 +168,6 @@ class DeadZoneAnalyzer(BasePreprocessor):
             dead_zone = self.DeadZone(self._last_event["timestamp"], event["timestamp"])
             self._dead_zones.append(dead_zone)
 
-    def _check_atramedes(self, event):
-        if event.get("target") != "Atramedes" and event.get("source") != "Atramedes":
-            return
-
-        current_time = event["timestamp"]
-
-        # Check if it's the first event
-        if self._last_timestamp == 0:
-            self._last_timestamp = current_time
-            return
-
-        phase_duration = 125000  # 125 seconds for a full cycle
-        current_phase_time = current_time % phase_duration
-
-        # Check for the air phase (85-125 seconds in each cycle)
-        if 85000 < current_phase_time <= 125000:
-            # If this is the start of an air phase, create a dead zone
-            if self._last_timestamp % phase_duration <= 85000:
-                dead_zone_start = (
-                    current_time // phase_duration
-                ) * phase_duration + 85000
-                dead_zone_end = dead_zone_start + 40000  # 40 seconds air phase
-                dead_zone = self.DeadZone(dead_zone_start, dead_zone_end)
-                self._dead_zones.append(dead_zone)
-
-        self._last_timestamp = current_time
-
     def _check_maexxna(self, event):
         if event["type"] not in ("removedebuff", "applydebuff"):
             return
@@ -271,7 +249,10 @@ class DeadZoneAnalyzer(BasePreprocessor):
         return None
 
     def get_dead_zones(self):
-        return [Window(window.start, window.end) for window in self._dead_zones]
+        return [
+            Window(window.start, min(window.end, self._fight.duration))
+            for window in self._dead_zones
+        ]
 
     def decorate_event(self, event):
         dead_zone = self.get_recent_dead_zone(event["timestamp"])
@@ -621,9 +602,7 @@ class RuneTracker(BaseAnalyzer):
 
             total_missing = 0
             for rune_type, num_needed in event["rune_cost"].items():
-                missing = max(
-                    0, num_needed - current_runes[rune_type]
-                )
+                missing = max(0, num_needed - current_runes[rune_type])
                 if missing > 0:
                     death_runes_needed = min(death_runes, missing)
                     missing -= death_runes_needed

--- a/backend/src/report.py
+++ b/backend/src/report.py
@@ -82,7 +82,9 @@ class Report:
     ):
         self.source = source
         self._events = events
-        self._deaths = {(death["targetID"], death.get("targetInstance")): death for death in deaths}
+        self._deaths = {
+            (death["targetID"], death.get("targetInstance")): death for death in deaths
+        }
         self._rankings = self._parse_rankings(rankings)
         self._combatant_info = combatant_info
         self._encounters = {
@@ -224,9 +226,7 @@ class Report:
         if ability_id == 60229:
             return "https://wow.zamimg.com/images/wow/icons/large/inv_inscription_tarotgreatness.jpg"
         if ability_id == 63560:
-            return (
-                "https://wow.zamimg.com/images/wow/icons/large/achievement_boss_festergutrotface.jpg"
-            )
+            return "https://wow.zamimg.com/images/wow/icons/large/achievement_boss_festergutrotface.jpg"
 
         for ability in self._abilities:
             if ability["gameID"] == ability_id:
@@ -235,9 +235,7 @@ class Report:
                 )
         else:
             if ability_id == 79634:
-                return (
-                    "https://wow.zamimg.com/images/wow/icons/large/inv_potiond_1.jpg"
-                )
+                return "https://wow.zamimg.com/images/wow/icons/large/inv_potiond_1.jpg"
             if ability_id == 48470:
                 return "https://wow.zamimg.com/images/wow/icons/large/spell_nature_giftofthewild.jpg"
             if ability_id == 79472:


### PR DESCRIPTION
Addresses https://github.com/ryancraigdavis/WCL_DK_Analyzer/issues/35

Atramedes deadzone detection didn't really work well (timestamps aren't accurate + it went over the fight duration). The existing simple dead zone detector works well though, added a melee_only detection so outbreak / death coil doesn't reset the dead zone