### PR TITLE
#44 New bis items added

### DIFF
--- a/backend/src/analysis/core_analysis.py
+++ b/backend/src/analysis/core_analysis.py
@@ -1424,98 +1424,6 @@ class TrinketAnalyzer(BaseAnalyzer):
         )
 
 
-class T11UptimeAnalyzer(BaseAnalyzer):
-    def __init__(
-        self,
-        fight_duration,
-        buff_tracker: BuffTracker,
-        items: ItemPreprocessor,
-        ignore_windows,
-    ):
-        self._fight_duration = fight_duration
-        self._items = items
-        self._has_4p = items.has_t11_4p()
-        self._t11_uptime = BuffUptimeAnalyzer(
-            fight_duration,
-            buff_tracker,
-            ignore_windows,
-            "Death Eater",
-        )
-
-    def add_event(self, event):
-        if not self._has_4p:
-            return
-
-        self._t11_uptime.add_event(event)
-
-    def report(self):
-        if not self._has_4p:
-            return {}
-
-        return {
-            "t11_uptime": self._t11_uptime.uptime(),
-            "t11_max_uptime": self._items.t11_max_uptime(),
-        }
-
-    def score(self):
-        if not self._has_4p:
-            return 0
-
-        return min(self._t11_uptime.score() / self._items.t11_max_uptime(), 1)
-
-    def score_weight(self):
-        if not self._has_4p:
-            return 0
-
-        return 2
-
-
-class T12UptimeAnalyzer(BaseAnalyzer):
-    def __init__(
-        self,
-        fight_duration,
-        buff_tracker: BuffTracker,
-        items: ItemPreprocessor,
-        ignore_windows,
-    ):
-        self._fight_duration = fight_duration
-        self._items = items
-        self._has_2p = items.has_t12_2p()
-        self._t12_uptime = BuffUptimeAnalyzer(
-            fight_duration,
-            buff_tracker,
-            ignore_windows,
-            "Death Eater",
-        )
-
-    def add_event(self, event):
-        if not self._has_2p:
-            return
-
-        self._t12_uptime.add_event(event)
-
-    def report(self):
-        if not self._has_2p:
-            return {}
-
-        return {
-            "t12_uptime": self._t12_uptime.uptime(),
-            "t12_max_uptime": self._items.t12_max_uptime(),
-        }
-
-    def score(self):
-        if not self._has_2p:
-            return 0
-
-        return min(self._t12_uptime.score() / self._items.t12_max_uptime(), 1)
-
-    def score_weight(self):
-        if not self._has_2p:
-            return 0
-
-        return 2
-
-
 class BuffUptimeAnalyzer(BaseAnalyzer):
     def __init__(
         self,
@@ -1599,12 +1507,6 @@ class CoreAnalysisScorer(AnalysisScorer):
             TrinketAnalyzer: {
                 "weight": lambda ta: ta.num_on_use_trinkets,
             },
-            T11UptimeAnalyzer: {
-                "weight": lambda t11a: t11a.score_weight(),
-            },
-            # T12UptimeAnalyzer: {
-            #     "weight": lambda t12a: t12a.score_weight(),
-            # },
         }
 
     def report(self):
@@ -1628,12 +1530,6 @@ class CoreAnalysisConfig:
             SynapseSpringsAnalyzer(fight.duration),
             MeleeUptimeAnalyzer(fight.duration, dead_zone_analyzer.get_dead_zones()),
             TrinketAnalyzer(fight.duration, items),
-            T11UptimeAnalyzer(
-                fight.duration, buff_tracker, items, dead_zone_analyzer.get_dead_zones()
-            ),
-            T12UptimeAnalyzer(
-                fight.duration, buff_tracker, items, dead_zone_analyzer.get_dead_zones()
-            ),
         ]
 
     def get_scorer(self, analyzers):

--- a/backend/src/analysis/items.py
+++ b/backend/src/analysis/items.py
@@ -46,28 +46,14 @@ class HasteTrinket(Trinket):
 
 class TrinketPreprocessor(BasePreprocessor):
     TRINKETS = [
-        APTrinket("Right Eye of Rajh", 56100, "Eye of Doom", 10, 50),
-        APTrinket("Right Eye of Rajh", 56431, "Eye of Doom", 10, 50),
-        APTrinket("Heart of Rage", 65072, "Rageheart", 20, 100),
-        APTrinket("Heart of Rage", 59224, "Rageheart", 20, 100),
-        APTrinket("License to Slay", 58180, "Slayer", 15, 100),
-        APTrinket(
-            "Impatience of Youth", 62464, "Thrill of Victory", 20, 120, on_use=True
-        ),
-        APTrinket(
-            "Impatience of Youth", 62469, "Thrill of Victory", 20, 120, on_use=True
-        ),
-        APTrinket("Might of the Ocean", 56285, "Typhoon", 15, 90, on_use=True),
-        APTrinket("Might of the Ocean", 55251, "Typhoon", 15, 90, on_use=True),
-        APTrinket("Magnetite Mirror", 56345, "Polarization", 15, 90, on_use=True),
-        APTrinket("Magnetite Mirror", 55814, "Polarization", 15, 90, on_use=True),
-        APTrinket("King of Boars", 52351, "King of Boars", 20, 120, on_use=True),
-        APTrinket("Fury of Angerforge", 59461, "Forged Fury", 20, 120, on_use=True),
-        APTrinket("Heart of Solace", 56393, "Heartened", 20, 100),
-        APTrinket("Heart of Solace", 55868, "Heartened", 20, 100),
-        HasteTrinket("Crushing Weight", 65118, "Race Against Death", 15, 75),
-        HasteTrinket("Crushing Weight", 59506, "Race Against Death", 15, 75),
-        HasteTrinket("Shrine-Cleansing Purifier", 63838, "Fatality", 20, 100),
+        APTrinket("Relic of Xuen", 79327, "Blessing of the Celestials", 15, 55),
+        APTrinket("Zen Alchemist Stone", 75274, "Zen Alchemist Stone", 15, 55),
+        HasteTrinket("Darkmist Vortex", 87172, "Alacrity", 20, 115),
+        HasteTrinket("Darkmist Vortex", 86894, "Alacrity", 20, 115),
+        HasteTrinket("Darkmist Vortex", 86336, "Alacrity", 20, 115),
+        APTrinket("Lei Shen's Final Orders", 87072, "Unwavering Might", 20, 55),
+        APTrinket("Lei Shen's Final Orders", 86144, "Unwavering Might", 20, 55),
+        APTrinket("Lei Shen's Final Orders", 86802, "Unwavering Might", 20, 55),
     ]
     TRINKET_MAP = {trinket.item_id: trinket for trinket in TRINKETS}
     TRINKEY_MAP_BY_BUFF_NAME = {trinket.buff_name: trinket for trinket in TRINKETS}
@@ -112,93 +98,53 @@ class TrinketPreprocessor(BasePreprocessor):
         return len(self._trinkets)
 
 
-class T11Preprocessor(BasePreprocessor):
-    def __init__(self, combatant_info):
-        self.has_4p = False
-        self._calc_num_t11(combatant_info)
+# class T15Preprocessor(BasePreprocessor):
+#     def __init__(self, combatant_info):
+#         self.has_4p = False
+#         self._calc_num_t15(combatant_info)
 
-    def _calc_num_t11(self, combatant_info):
-        count = 0
+#     def _calc_num_t15(self, combatant_info):
+#         count = 0
 
-        for item in combatant_info.get("gear", []):
-            if item["id"] in {
-                # Head
-                65181,
-                60341,
-                # Shoulders
-                65183,
-                60343,
-                # Chest
-                65179,
-                60339,
-                # Legs
-                65182,
-                60342,
-                # Hands
-                65180,
-                60340,
-            }:
-                count += 1
-        if count >= 4:
-            self.has_4p = True
+#         for item in combatant_info.get("gear", []):
+#             if item["id"] in {
+#                 # Head
+#                 65181,
+#                 60341,
+#                 # Shoulders
+#                 65183,
+#                 60343,
+#                 # Chest
+#                 65179,
+#                 60339,
+#                 # Legs
+#                 65182,
+#                 60342,
+#                 # Hands
+#                 65180,
+#                 60340,
+#             }:
+#                 count += 1
+#         if count >= 4:
+#             self.has_4p = True
 
-    def preprocess_event(self, event):
-        if event["type"] == "applybuff" and event["ability"] == "Death Eater":
-            self.has_4p = True
+#     def preprocess_event(self, event):
+#         if event["type"] == "applybuff" and event["ability"] == "Death Eater":
+#             self.has_4p = True
 
-    @property
-    def max_uptime(self):
-        return 0.98
-
-
-class T12Preprocessor(BasePreprocessor):
-    def __init__(self, combatant_info):
-        self.has_2p = False
-        self._calc_num_t12(combatant_info)
-
-    def _calc_num_t12(self, combatant_info):
-        count = 0
-        for item in combatant_info.get("gear", []):
-            if item["id"] in {
-                # Head
-                71478,
-                71060,
-                # Shoulders
-                71480,
-                71062,
-                # Chest
-                71058,
-                71476,
-                # Legs
-                71479,
-                71061,
-                # Hands
-                71477,
-                71059,
-            }:
-                count += 1
-        if count >= 2:
-            self.has_2p = True
-
-    def preprocess_event(self, event):
-        if event["type"] == "applybuff" and event["ability"] == "Smoldering Rune":
-            self.has_2p = True
-
-    @property
-    def max_uptime(self):
-        return 0.98
+#     @property
+#     def max_uptime(self):
+#         return 0.98
 
 
 class ItemPreprocessor(BasePreprocessor):
     def __init__(self, combatant_info):
         self._trinkets = TrinketPreprocessor(combatant_info)
-        self._t11 = T11Preprocessor(combatant_info)
-        self._t12 = T12Preprocessor(combatant_info)
+        # self._t15 = T15Preprocessor(combatant_info)
 
         self._processors = [
             self._trinkets,
-            self._t11,
-            self._t12,
+            # self._t15,
         ]
 
     def preprocess_event(self, event):
@@ -208,17 +154,8 @@ class ItemPreprocessor(BasePreprocessor):
     def has_trinket(self, buff_name):
         return self._trinkets.has_trinket(buff_name)
 
-    def has_t11_4p(self):
-        return self._t11.has_4p
-
-    def has_t12_2p(self):
-        return self._t12.has_2p
-
-    def t11_max_uptime(self):
-        return self._t11.max_uptime
-
-    def t12_max_uptime(self):
-        return self._t12.max_uptime
+    # def has_t14_4p(self):
+    #     return self._t15.has_4p
 
     @property
     def trinkets(self):

--- a/backend/src/analysis/unholy_analysis.py
+++ b/backend/src/analysis/unholy_analysis.py
@@ -22,8 +22,7 @@ from analysis.core_analysis import (
     MeleeUptimeAnalyzer,
     TrinketAnalyzer,
     BuffUptimeAnalyzer,
-    T11UptimeAnalyzer,
-    T12UptimeAnalyzer,
+    # T15UptimeAnalyzer,
     RuneHasteTracker,
 )
 from analysis.items import ItemPreprocessor
@@ -487,9 +486,6 @@ class GargoyleWindow(Window):
         self.snapshotted_synapse = buff_tracker.is_active("Synapse Springs", start)
         self.snapshotted_fc = buff_tracker.is_active("Unholy Strength", start)
         self.snapshotted_potion = buff_tracker.is_active("Golem's Strength", start)
-        self.snapshotted_t11 = (
-            buff_tracker.is_active("Death Eater", start) if items.has_t11_4p() else None
-        )
         self.snapshotted_bloodfury = (
             buff_tracker.is_active("Blood Fury", start)
             if buff_tracker.has_bloodfury
@@ -550,10 +546,6 @@ class GargoyleWindow(Window):
                 len([t for t in self.trinket_snapshots if t["did_snapshot"]])
                 / (len(self.trinket_snapshots) if self.trinket_snapshots else 1),
                 len(self.trinket_snapshots) * 2,
-            ),
-            ScoreWeight(
-                int(self.snapshotted_t11) if self.snapshotted_t11 is not None else 0,
-                2 if self.snapshotted_t11 is not None else 0,
             ),
             ScoreWeight(
                 (
@@ -624,7 +616,6 @@ class GargoyleAnalyzer(BaseAnalyzer):
                         "snapshotted_synapse": window.snapshotted_synapse,
                         "snapshotted_potion": window.snapshotted_potion,
                         "snapshotted_fc": window.snapshotted_fc,
-                        "snapshotted_t11": window.snapshotted_t11,
                         "snapshotted_bloodfury": window.snapshotted_bloodfury,
                         "num_casts": window.num_casts,
                         "num_melees": window.num_melees,
@@ -959,12 +950,6 @@ class UnholyAnalysisScorer(AnalysisScorer):
             TrinketAnalyzer: {
                 "weight": lambda ta: ta.num_on_use_trinkets * 2,
             },
-            T11UptimeAnalyzer: {
-                "weight": lambda t11a: t11a.score_weight(),
-            },
-            # T12UptimeAnalyzer: {
-            #     "weight": lambda t12a: t12a.score_weight(),
-            # },
             BloodTapAnalyzer: {
                 "weight": 1,
             },

--- a/frontend/src/Analysis.jsx
+++ b/frontend/src/Analysis.jsx
@@ -363,7 +363,6 @@ const Summary = () => {
           {summary.obliterate && formatCPM(summary.obliterate.cpm, summary.obliterate.target_cpm, "Obliterate")}
           {summary.dnd !== undefined && formatUpTime(summary.dnd.uptime, "Death and Decay", false, summary.dnd.max_uptime)}
           {summary.dark_transformation_uptime !== undefined && formatUpTime(summary.dark_transformation_uptime, "Dark Transformation", false, summary.dark_transformation_max_uptime)}
-          {summary.t11_uptime !== undefined && formatUpTime(summary.t11_uptime, "Death Eater (T11 4p)", false, summary.t11_max_uptime)}
           {summary.melee_uptime !== undefined && formatUpTime(summary.melee_uptime, "Melee")}
           {summary.unbreakable_armor && formatUA(summary.unbreakable_armor)}
           {summary.blood_plague_uptime !== undefined && formatUpTime(summary.blood_plague_uptime, "Blood Plague")}

--- a/frontend/src/GargoyleAnalysis.jsx
+++ b/frontend/src/GargoyleAnalysis.jsx
@@ -36,7 +36,6 @@ export const GargoyleAnalysis = ({ gargoyle }) => {
                 {booleanCheck(window.snapshotted_potion, "You snapshotted your Golemsblood Potion", "You did not snapshot your Golemsblood Potion")}
                 {booleanCheck(window.snapshotted_fc, "You snapshotted Fallen Crusader", "You did not snapshot Fallen Crusader")}
                 {window.snapshotted_bloodfury !== null && booleanCheck(window.snapshotted_bloodfury, "You snapshotted Blood Fury", "You did not snapshot Blood Fury")}
-                {window.snapshotted_t11 !== null && booleanCheck(window.snapshotted_t11, "You snapshotted Death Eater (T11 4p)", "You did not snapshot Death Eater (T11 4p)")}
               </div>
             )
           })}


### PR DESCRIPTION
This pull request removes all code related to the T11 and T12 set bonus analyzers from both the backend analysis logic and the frontend display. It also updates the trinket definitions to include new trinkets and removes the T11/T12 set bonus preprocessors from the item preprocessing pipeline. The changes simplify the codebase by eliminating unused or outdated set bonus logic.

**Removal of T11/T12 Set Bonus Logic:**

* Removed the `T11UptimeAnalyzer` and `T12UptimeAnalyzer` classes from `core_analysis.py`, as well as all related logic for scoring, reporting, and analyzer instantiation. [[1]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L1427-L1518) [[2]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L1602-L1607) [[3]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L1631-L1636)
* Deleted the `T11Preprocessor` and `T12Preprocessor` from `items.py`, and removed their integration with `ItemPreprocessor`. [[1]](diffhunk://#diff-256cf28dc74edaa5e8978ff52060ee3936fc477eb9e7d6f72b2e2049dea35c9fL115-R147) [[2]](diffhunk://#diff-256cf28dc74edaa5e8978ff52060ee3936fc477eb9e7d6f72b2e2049dea35c9fL211-R158)
* Removed all frontend references to T11 set bonus reporting, including summary and Gargoyle snapshot checks. [[1]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1L366) [[2]](diffhunk://#diff-dee74de20921f94a4be2119bd9e720e24f7a969fa11c294b216590ab03608ff9L39)
* Removed all T11/T12 analyzer imports and usage from `unholy_analysis.py`, including snapshot and score logic. [[1]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL25-R25) [[2]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL490-L492) [[3]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL554-L557) [[4]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL627) [[5]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL962-L967)

**Trinket Updates:**

* Updated the trinket list in `TrinketPreprocessor` to include new trinkets and remove outdated ones, reflecting a shift to newer content.

**Codebase Maintenance:**

* Commented out a placeholder for a potential T15 set bonus preprocessor, indicating possible future expansion but no current implementation. [[1]](diffhunk://#diff-256cf28dc74edaa5e8978ff52060ee3936fc477eb9e7d6f72b2e2049dea35c9fL115-R147) [[2]](diffhunk://#diff-256cf28dc74edaa5e8978ff52060ee3936fc477eb9e7d6f72b2e2049dea35c9fL211-R158)

These changes streamline the analysis pipeline by focusing on currently relevant items and removing legacy set bonus logic.