### PR TITLE
#8 Festering Strike tracker added

### DIFF
--- a/frontend/src/Analysis.jsx
+++ b/frontend/src/Analysis.jsx
@@ -296,6 +296,29 @@ const Summary = () => {
     )
   }, [])
 
+  const formatFesteringStrikeWaste = useCallback(festeringStrikeWaste => {
+    const oneDeathRune = festeringStrikeWaste.one_death_rune_casts
+    const twoDeathRune = festeringStrikeWaste.two_death_rune_casts
+    const totalWasted = festeringStrikeWaste.total_death_runes_wasted
+
+    let icon = <i className="fa fa-check green" aria-hidden="true"></i>
+    if (totalWasted > 5) {
+      icon = <i className="fa fa-times red" aria-hidden="true"></i>
+    } else if (totalWasted > 2) {
+      icon = <i className="fa fa-warning yellow" aria-hidden="true"></i>
+    }
+
+    return (
+      <div className={"festering-strike-waste"}>
+        {icon}
+        Festering Strike wasted <span className={"hl"}>{totalWasted}</span> death runes
+        {totalWasted > 0 && (
+          <span> (<span className={"hl"}>{oneDeathRune}</span> × 1DR, <span className={"hl"}>{twoDeathRune}</span> × 2DR)</span>
+        )}
+      </div>
+    )
+  }, [])
+
   const formatScore = useCallback(score => {
     let color = "red"
     if (score > 0.8) {
@@ -389,6 +412,7 @@ const Summary = () => {
           {summary.frost_fever_uptime !== undefined && formatUpTime(summary.frost_fever_uptime, "Frost Fever")}
           {summary.unholy_presence_uptime !== undefined && formatUpTime(summary.unholy_presence_uptime, "Unholy Presence")}
           {summary.blood_tap_usages !== undefined && formatUsage(summary.blood_tap_usages, summary.blood_tap_max_usages, "Blood Tap")}
+          {summary.festering_strike_waste && formatFesteringStrikeWaste(summary.festering_strike_waste)}
           {summary.diseases_dropped && formatDiseases(summary.diseases_dropped)}
           {summary.raise_dead_usage && formatUsage(summary.raise_dead_usage.num_usages, summary.raise_dead_usage.possible_usages, "Raise Dead")}
           {summary.howling_blast_bad_usages && formatHowlingBlast(summary.howling_blast_bad_usages)}
@@ -450,14 +474,14 @@ export const Analysis = () => {
 
   const formatEvent = useCallback((event, showRunes, showProcs, i) => {
     const abilityIcon = event.ability_icon;
-    const icon = (
+    const icon = abilityIcon ? (
       <img
         src={abilityIcon}
         title={event.ability}
         alt={event.ability}
         width={20}
       />
-    );
+    ) : null;
     const offset = event.gcd_offset;
     let ability = event.ability;
     let timestamp = <span>{formatTimestamp(event.timestamp)}</span>;
@@ -487,6 +511,11 @@ export const Analysis = () => {
     if (event.type === "removebuff") {
       abilityTdClass = "buff-drops";
       ability = `${ability} ends`;
+    }
+
+    if (event.type === "death_rune_waste") {
+      abilityTdClass = "death-rune-waste";
+      ability = `${ability} wasted ${event.death_runes_wasted} death rune${event.death_runes_wasted > 1 ? 's' : ''}`;
     }
 
     if (event.is_miss) {


### PR DESCRIPTION
This pull request introduces a new analyzer for tracking Festering Strike death rune waste in Unholy Death Knight analysis. It adds backend logic to detect and report suboptimal Festering Strike casts and surfaces this information in both the summary and timeline views on the frontend. The changes are grouped into backend analysis enhancements and frontend display updates.

**Backend analysis enhancements:**

* Added `FesteringStrikeTracker` to the backend, which tracks when Festering Strike is cast using death runes instead of blood/frost runes, records waste events, and provides scoring/reporting based on the number of wasted runes.
* Integrated `FesteringStrikeTracker` into the Unholy analysis pipeline by including it in the list of analyzers and assigning a score weight for its contribution to the overall analysis. [[1]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdR1263) [[2]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdR1224-R1227)
* Modified the main analysis class to store references to analyzers and to append Festering Strike waste events to the displayable events timeline, ensuring these events are visible in the UI. [[1]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaL15-R15) [[2]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaR36) [[3]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaR282) [[4]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaR204) [[5]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaR235-R262)

**Frontend display updates:**

* Added a summary section to visually report Festering Strike death rune waste, showing counts and a traffic-light icon based on severity. [[1]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R299-R321) [[2]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R415)
* Updated the event timeline rendering to highlight Festering Strike waste events with a distinct style and description, making them stand out in the analysis. [[1]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R516-R520) [[2]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1L453-R484)