### PR TITLE
#56 Blood charge tracking added

### DIFF
--- a/backend/src/analysis/analyze.py
+++ b/backend/src/analysis/analyze.py
@@ -7,6 +7,7 @@ from analysis.core_analysis import (
     DebuffTracker,
     PetNameDetector,
     RuneHasteTracker,
+    BloodChargeCapAnalyzer,
 )
 from analysis.frost_analysis import (
     FrostAnalysisConfig,
@@ -233,7 +234,7 @@ class Analyzer:
             ):
                 events.append(event)
 
-        # Add death rune waste events from FesteringStrikeTracker
+        # Add death rune waste events from FesteringStrikeTracker and blood charge cap events
         if hasattr(self, '_analyzers'):
             for analyzer in self._analyzers:
                 if isinstance(analyzer, FesteringStrikeTracker):
@@ -247,6 +248,28 @@ class Analyzer:
                             "targetID": self._fight.source.id,
                             "death_runes_wasted": waste_event["death_runes_wasted"],
                             "message": waste_event["message"],
+                            "buffs": [],  # Will be decorated later
+                            "debuffs": [],  # Will be decorated later
+                            "runes_before": [],  # Empty runes for display events
+                            "runes": [],  # Empty runes for display events
+                            "runic_power": 0,  # Default RP
+                            "modifies_runes": False,  # Don't show rune changes
+                            "has_gcd": False,  # Not a GCD event
+                            "ability_type": 0,  # Default ability type
+                        }
+                        events.append(timeline_event)
+
+                if isinstance(analyzer, BloodChargeCapAnalyzer):
+                    for cap_event in analyzer._cap_events:
+                        # Create a timeline event for blood charge caps
+                        timeline_event = {
+                            "timestamp": cap_event["timestamp"],
+                            "type": "blood_charge_cap",
+                            "ability": cap_event["ability"],
+                            "sourceID": self._fight.source.id,
+                            "targetID": self._fight.source.id,
+                            "charges_wasted": cap_event["charges_wasted"],
+                            "message": cap_event["message"],
                             "buffs": [],  # Will be decorated later
                             "debuffs": [],  # Will be decorated later
                             "runes_before": [],  # Empty runes for display events

--- a/backend/src/analysis/unholy_analysis.py
+++ b/backend/src/analysis/unholy_analysis.py
@@ -1109,35 +1109,6 @@ class SnapshottableBuff:
         return any(buff_tracker.is_active(buff, timestamp) for buff in self.buffs)
 
 
-class BloodTapAnalyzer(BaseAnalyzer):
-    def __init__(self, fight_end_time):
-        self._num_used = 0
-        self._max_blood_tap_cooldown = 60000
-        self._fight_end_time = fight_end_time
-
-    @property
-    def max_usages(self):
-        return max(
-            1
-            + (self._fight_end_time - (self._max_blood_tap_cooldown / 2))
-            // self._max_blood_tap_cooldown,
-            self._num_used,
-        )
-
-    def add_event(self, event):
-        self._max_blood_tap_cooldown = event["blood_tap_cooldown"]
-        if event["type"] == "cast" and event["ability"] == "Blood Tap":
-            self._num_used += 1
-
-    def score(self):
-        return self._num_used / self.max_usages
-
-    def report(self):
-        return {
-            "blood_tap_usages": self._num_used,
-            "blood_tap_max_usages": self.max_usages,
-        }
-
 
 class AMSAnalyzer(BaseAnalyzer):
     def __init__(self, fight_end_time):
@@ -1218,9 +1189,6 @@ class UnholyAnalysisScorer(AnalysisScorer):
             TrinketAnalyzer: {
                 "weight": lambda ta: ta.num_on_use_trinkets * 2,
             },
-            BloodTapAnalyzer: {
-                "weight": 1,
-            },
             FesteringStrikeTracker: {
                 "weight": 2,
                 "exponent_factor": exponent_factor,
@@ -1259,7 +1227,6 @@ class UnholyAnalysisConfig(CoreAnalysisConfig):
             GhoulAnalyzer(fight.duration, dead_zones),
             UnholyPresenceUptimeAnalyzer(fight.duration, buff_tracker, dead_zones),
             ArmyAnalyzer(),
-            BloodTapAnalyzer(fight.end_time),
             FesteringStrikeTracker(),
             SoulReaperAnalyzer(fight.duration, fight.end_time),
             # AMSAnalyzer(fight.end_time)

--- a/frontend/src/Analysis.jsx
+++ b/frontend/src/Analysis.jsx
@@ -319,6 +319,28 @@ const Summary = () => {
     )
   }, [])
 
+  const formatBloodChargeCaps = useCallback(bloodChargeCaps => {
+    if (!bloodChargeCaps.has_blood_tap_talent) {
+      return null // Don't show if player doesn't have Blood Tap talent
+    }
+
+    const totalCaps = bloodChargeCaps.total_caps
+    const totalWasted = bloodChargeCaps.total_charges_wasted
+    let icon = <i className="fa fa-check green" aria-hidden="true"></i>
+    if (totalCaps > 5) {
+      icon = <i className="fa fa-times red" aria-hidden="true"></i>
+    } else if (totalCaps > 2) {
+      icon = <i className="fa fa-warning yellow" aria-hidden="true"></i>
+    }
+
+    return (
+      <div className={"blood-charge-caps"}>
+        {icon}
+        Blood Charge caps: <span className={"hl"}>{totalCaps}</span> times ({totalWasted} charges wasted)
+      </div>
+    )
+  }, [])
+
   const formatScore = useCallback(score => {
     let color = "red"
     if (score > 0.8) {
@@ -411,7 +433,7 @@ const Summary = () => {
           {summary.blood_plague_uptime !== undefined && formatUpTime(summary.blood_plague_uptime, "Blood Plague")}
           {summary.frost_fever_uptime !== undefined && formatUpTime(summary.frost_fever_uptime, "Frost Fever")}
           {summary.unholy_presence_uptime !== undefined && formatUpTime(summary.unholy_presence_uptime, "Unholy Presence")}
-          {summary.blood_tap_usages !== undefined && formatUsage(summary.blood_tap_usages, summary.blood_tap_max_usages, "Blood Tap")}
+          {summary.blood_charge_caps && formatBloodChargeCaps(summary.blood_charge_caps)}
           {summary.festering_strike_waste && formatFesteringStrikeWaste(summary.festering_strike_waste)}
           {summary.diseases_dropped && formatDiseases(summary.diseases_dropped)}
           {summary.raise_dead_usage && formatUsage(summary.raise_dead_usage.num_usages, summary.raise_dead_usage.possible_usages, "Raise Dead")}
@@ -489,6 +511,7 @@ export const Analysis = () => {
       3,
       " "
     );
+    let bloodCharges = String(event.blood_charges || 0).padStart(2, " ");
 
     let abilityTdClass = "";
     let abilityDivClass = "ability";
@@ -591,6 +614,9 @@ export const Analysis = () => {
         <td>
           <div className={"runic-power"}>{runicPower}</div>
         </td>
+        <td>
+          <div className={"blood-charges"}>{bloodCharges}</div>
+        </td>
         {showRunes ? (
           <>
             <td>
@@ -658,6 +684,7 @@ export const Analysis = () => {
               <th>Time</th>
               <th>Ability</th>
               <th>RP</th>
+              <th>BC</th>
               {summary.has_rune_spend_error ? null : (
                 <>
                   <th>Runes</th>


### PR DESCRIPTION
This pull request introduces a new analyzer for tracking Blood Charge cap waste related to the Blood Tap talent, replaces the previous Blood Tap usage analyzer, and updates both backend and frontend to report and visualize Blood Charge cap events and waste. The changes improve the accuracy and clarity of analysis for players using the Blood Tap talent by tracking wasted charges when the cap is reached, and displaying this information in the analysis summary and timeline.

**Backend analysis improvements:**

* Added `BloodChargeCapAnalyzer` to track Blood Charge cap events, wasted charges, and provide scoring/reporting based on talent presence and waste severity. (`backend/src/analysis/core_analysis.py` [[1]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71R1353-R1450) [[2]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71R1689-R1691) [[3]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71R1707-R1715)
* Integrated `BloodChargeCapAnalyzer` into the analyzer pipeline for both core and frost analysis, and removed the old `BloodTapAnalyzer` and its references from unholy analysis. (`backend/src/analysis/analyze.py` [[1]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaR10) [[2]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaL236-R237) [[3]](diffhunk://#diff-ffad0550e43afeaf60b3db64832d080c6c2da40f0db6c8ccf5b01a2bb4e5dffaR262-R283); `backend/src/analysis/unholy_analysis.py` [[4]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1112-L1140) [[5]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1221-L1223) [[6]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1262)

**Frontend visualization updates:**

* Added a summary display for Blood Charge cap events, showing number of caps and charges wasted, with status icons based on severity. (`frontend/src/Analysis.jsx` [[1]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R322-R343) [[2]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1L414-R436)
* Updated the analysis timeline to include a new "BC" (Blood Charges) column, showing the number of charges before/after relevant events. (`frontend/src/Analysis.jsx` [[1]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R514) [[2]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R617-R619) [[3]](diffhunk://#diff-043b4196e1dc453fc5158998007e427e298ef36ba454f8c0ef7f8ce8f6b99aa1R687)