### PR TITLE
#64 Army and Raise dead tracking added

### DIFF
--- a/backend/src/analysis/unholy_analysis.py
+++ b/backend/src/analysis/unholy_analysis.py
@@ -24,6 +24,7 @@ from analysis.core_analysis import (
     # T15UptimeAnalyzer,
     RuneHasteTracker,
     SoulReaperAnalyzer,
+    ArmyAnalyzer,
 )
 from analysis.items import ItemPreprocessor
 from report import Fight
@@ -994,28 +995,7 @@ class GhoulAnalyzer(BaseAnalyzer):
         }
 
 
-class ArmyAnalyzer(BaseAnalyzer):
-    INCLUDE_PET_EVENTS = True
-
-    def __init__(self):
-        self.total_damage = 0
-
-    def add_event(self, event):
-        if event["type"] == "damage" and event["source"] == "Army of the Dead":
-            self.total_damage += event["amount"]
-
-    def report(self):
-        return {
-            "army": {
-                "damage": self.total_damage,
-            }
-        }
-
-    def score(self):
-        if self.total_damage >= 100000:
-            return 1
-        else:
-            return self.total_damage / 100000
+# ArmyAnalyzer moved to core_analysis.py for shared use between Frost and Unholy
 
 
 
@@ -1326,7 +1306,7 @@ class UnholyAnalysisConfig(CoreAnalysisConfig):
             DeathAndDecayUptimeAnalyzer(fight.duration, dead_zones, items),
             GhoulAnalyzer(fight.duration, dead_zones),
             UnholyPresenceUptimeAnalyzer(fight.duration, buff_tracker, dead_zones),
-            ArmyAnalyzer(),
+            ArmyAnalyzer(fight.duration, buff_tracker, dead_zones, items),
             FesteringStrikeTracker(),
             SoulReaperAnalyzer(fight.duration, fight.end_time),
             OutbreakSnapshotTracker(buff_tracker, combatant_info),

--- a/frontend/src/Analysis.jsx
+++ b/frontend/src/Analysis.jsx
@@ -6,9 +6,11 @@ import FrostRune from "./assets/frost_rune.webp";
 import UnholyRune from "./assets/unholy_rune.webp";
 import DeathRune from "./assets/death_rune.webp";
 import { ArmyAnalysis } from "./ArmyAnalysis.jsx"
+import { ArmyDynamicAnalysis } from "./ArmyDynamicAnalysis.jsx"
 import { GargoyleAnalysis } from "./GargoyleAnalysis"
 import { DarkTransformationAnalysis } from "./DarkTransformationAnalysis"
 import { GhoulAnalysis } from "./GhoulAnalysis.jsx"
+import { RaiseDeadAnalysis } from "./RaiseDeadAnalysis.jsx"
 import { SoulReaperAnalysis } from "./SoulReaperAnalysis.jsx"
 import { OutbreakAnalysis } from "./OutbreakAnalysis.jsx"
 import { Tabs, Tab } from "./Tabs.jsx"
@@ -822,7 +824,6 @@ const Summary = () => {
               {summary.blood_charge_caps && formatBloodChargeCaps(summary.blood_charge_caps)}
               {summary.festering_strike_waste && formatFesteringStrikeWaste(summary.festering_strike_waste)}
               {summary.diseases_dropped && formatDiseases(summary.diseases_dropped)}
-              {summary.raise_dead_usage && formatUsage(summary.raise_dead_usage.num_usages, summary.raise_dead_usage.possible_usages, "Raise Dead")}
               {summary.howling_blast_bad_usages && formatHowlingBlast(summary.howling_blast_bad_usages)}
               {summary.runic_power && formatRunicPower(summary.runic_power)}
               {summary.rime && formatRime(summary.rime)}
@@ -871,6 +872,11 @@ const Summary = () => {
                 <GhoulAnalysis ghoul={summary.ghoul} />
               </div>
             )}
+            {summary.raise_dead && (
+              <div className="analysis-section">
+                <RaiseDeadAnalysis raise_dead={summary.raise_dead} />
+              </div>
+            )}
             {summary.dark_transformation && (
               <div className="analysis-section">
                 <DarkTransformationAnalysis dark_transformation={summary.dark_transformation} />
@@ -884,6 +890,11 @@ const Summary = () => {
             {summary.army && (
               <div className="analysis-section">
                 <ArmyAnalysis army={summary.army} />
+              </div>
+            )}
+            {summary.army_dynamic && (
+              <div className="analysis-section">
+                <ArmyDynamicAnalysis army_dynamic={summary.army_dynamic} />
               </div>
             )}
           </div>

--- a/frontend/src/App.scss
+++ b/frontend/src/App.scss
@@ -220,6 +220,34 @@ tr:hover {
   margin-bottom: 5px;
 }
 
+.raise-dead-window {
+  margin-top: 12px;
+  > div {
+    margin-bottom: 2px;
+  }
+}
+.raise-dead-window:nth-child(even) {
+  margin-top: 20px;
+}
+.raise-dead-subheader {
+  font-size: 1.1em;
+  margin-bottom: 5px;
+}
+
+.army-window {
+  margin-top: 12px;
+  > div {
+    margin-bottom: 2px;
+  }
+}
+.army-window:nth-child(even) {
+  margin-top: 20px;
+}
+.army-subheader {
+  font-size: 1.1em;
+  margin-bottom: 5px;
+}
+
 .dark-transformation-window {
   margin-top: 12px;
 

--- a/frontend/src/ArmyDynamicAnalysis.jsx
+++ b/frontend/src/ArmyDynamicAnalysis.jsx
@@ -1,0 +1,82 @@
+import {formatIcon, formatTimestamp, formatUpTime, formatUsage, hl, Info} from "./helpers"
+
+
+export const ArmyDynamicAnalysis = ({ army_dynamic }) => {
+  const { windows } = army_dynamic
+
+  return (
+    <div>
+      <h3>Army of the Dead</h3>
+      <div>
+        {formatUsage(army_dynamic.num_actual, army_dynamic.num_possible, "Army of the Dead")}
+        <div className="windows">
+          {windows.length === 0 && army_dynamic.num_actual === 0 ? (
+            <div className="no-windows">
+              <i className="fa fa-info-circle hl" aria-hidden="true"></i>
+              No Army of the Dead casts detected. Cast Army of the Dead to see detailed buff analysis during army windows.
+            </div>
+          ) : null}
+          {windows.map((window, i) => {
+            const numAttacks = window.num_attacks
+
+            return (
+              <div className="army-window" key={i}>
+                <div className="army-subheader">
+                  <b>Army {i+1}:</b> ({hl(formatTimestamp(window.start))} - {hl(formatTimestamp(window.end))})
+                </div>
+                <div>
+                  {Info}
+                  <span>Damage: {hl(window.damage.toLocaleString())} ({hl(numAttacks)} attacks)</span>
+                </div>
+                {window.trinket_snapshots
+                  .filter(snapshot => snapshot.uptime !== 0)
+                  .map((snapshot, i) => {
+                    const icon = formatIcon(snapshot.name, snapshot.icon)
+                    return (
+                      <div key={i}>
+                        {formatUpTime(snapshot.uptime, <>{icon} {snapshot.name}</>)}
+                      </div>
+                    )
+                  })
+                }
+                <div>
+                  {formatUpTime(window.fallen_crusader_uptime, "Fallen Crusader")}
+                </div>
+                {window.synapse_springs_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.synapse_springs_uptime, "Synapse Springs")}
+                  </div>
+                )}
+                {window.potion_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.potion_uptime, "Potion of Mogu Power")}
+                  </div>
+                )}
+                {window.bloodfury_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.bloodfury_uptime, "Blood Fury")}
+                  </div>
+                )}
+                {window.berserking_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.berserking_uptime, "Berserking")}
+                  </div>
+                )}
+                {window.bloodlust_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.bloodlust_uptime, "Bloodlust")}
+                  </div>
+                )}
+                {window.pillar_of_frost_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.pillar_of_frost_uptime, "Pillar of Frost")}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/RaiseDeadAnalysis.jsx
+++ b/frontend/src/RaiseDeadAnalysis.jsx
@@ -1,0 +1,82 @@
+import {formatIcon, formatTimestamp, formatUpTime, formatUsage, hl, Info} from "./helpers"
+
+
+export const RaiseDeadAnalysis = ({ raise_dead }) => {
+  const { windows } = raise_dead
+
+  return (
+    <div>
+      <h3>Raise Dead (Frost Ghoul)</h3>
+      <div>
+        {formatUsage(raise_dead.num_actual, raise_dead.num_possible, "Raise Dead")}
+        <div className="windows">
+          {windows.length === 0 && raise_dead.num_actual === 0 ? (
+            <div className="no-windows">
+              <i className="fa fa-info-circle hl" aria-hidden="true"></i>
+              No Raise Dead casts detected. Cast Raise Dead to see detailed buff analysis during ghoul windows.
+            </div>
+          ) : null}
+          {windows.map((window, i) => {
+            const numAttacks = window.num_attacks
+
+            return (
+              <div className="raise-dead-window" key={i}>
+                <div className="raise-dead-subheader">
+                  <b>Ghoul {i+1}:</b> ({hl(formatTimestamp(window.start))} - {hl(formatTimestamp(window.end))})
+                </div>
+                <div>
+                  {Info}
+                  <span>Damage: {hl(window.damage.toLocaleString())} ({hl(numAttacks)} attacks)</span>
+                </div>
+                {window.trinket_snapshots
+                  .filter(snapshot => snapshot.uptime !== 0)
+                  .map((snapshot, i) => {
+                    const icon = formatIcon(snapshot.name, snapshot.icon)
+                    return (
+                      <div key={i}>
+                        {formatUpTime(snapshot.uptime, <>{icon} {snapshot.name}</>)}
+                      </div>
+                    )
+                  })
+                }
+                <div>
+                  {formatUpTime(window.fallen_crusader_uptime, "Fallen Crusader")}
+                </div>
+                {window.synapse_springs_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.synapse_springs_uptime, "Synapse Springs")}
+                  </div>
+                )}
+                {window.potion_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.potion_uptime, "Potion of Mogu Power")}
+                  </div>
+                )}
+                {window.bloodfury_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.bloodfury_uptime, "Blood Fury")}
+                  </div>
+                )}
+                {window.berserking_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.berserking_uptime, "Berserking")}
+                  </div>
+                )}
+                {window.bloodlust_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.bloodlust_uptime, "Bloodlust")}
+                  </div>
+                )}
+                {window.pillar_of_frost_uptime !== 0 && (
+                  <div>
+                    {formatUpTime(window.pillar_of_frost_uptime, "Pillar of Frost")}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
This pull request introduces dynamic buff snapshotting and performance analysis for pet windows (Army of the Dead and Raise Dead) in both Unholy and Frost specializations. It adds new analyzers and window classes to track buffs, trinket uptimes, and damage during pet summon windows, and updates the reporting and scoring logic to provide detailed insights for each window. The changes also ensure compatibility with frontend expectations and improve the modularity and extensibility of the analysis code.

**Pet Window Buff Snapshotting and Scoring:**

- Added `ArmyAnalyzer` and `ArmyWindow` classes to `core_analysis.py` for tracking Army of the Dead windows, including dynamic buff uptimes, trinket snapshots, attack counts, and total damage. The scoring system now weights buff uptimes, trinket effects, and attack performance during the army window.
- Added `RaiseDeadAnalyzer` and `RaiseDeadWindow` classes to `frost_analysis.py` for Frost DKs, providing similar buff and trinket tracking for Raise Dead windows. The analyzer tracks per-window damage, buff/trinket uptimes, and attack counts, and updates the report output to include detailed window data.

**Integration into Frost Analysis:**

- Updated the analyzer registration in `FrostAnalysisConfig.get_analyzers()` to use the new `RaiseDeadAnalyzer` and add `ArmyAnalyzer`, ensuring both analyzers are included in Frost DK analysis.
- Adjusted scoring weights for `RaiseDeadAnalyzer` to use an exponent factor, reflecting the increased complexity and importance of proper Raise Dead usage.

**Type and Import Updates:**

- Updated imports and type hints to support new analyzers and window classes, including `ScoreWeight`, `BuffUptimeAnalyzer`, and `ArmyAnalyzer` where needed. [[1]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L4-R11) [[2]](diffhunk://#diff-920ed46955bc2a9d634e91605baab3698d8ce73939306f85687ac6c402eab36cL1-R3) [[3]](diffhunk://#diff-920ed46955bc2a9d634e91605baab3698d8ce73939306f85687ac6c402eab36cR18-R19) [[4]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdR27)

These changes significantly enhance the detail and accuracy of pet summon analysis, providing actionable feedback on buff snapshotting and performance during key cooldown windows.

- Pet Window Analysis Enhancements:
  - Added `ArmyAnalyzer`/`ArmyWindow` and `RaiseDeadAnalyzer`/`RaiseDeadWindow` for dynamic buff/trinket tracking and scoring during Army of the Dead and Raise Dead windows. [[1]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71R1812-R2114) [[2]](diffhunk://#diff-920ed46955bc2a9d634e91605baab3698d8ce73939306f85687ac6c402eab36cL245-R545)
  - Updated report outputs to include detailed per-window data for frontend compatibility.
- Frost Analysis Integration:
  - Registered new analyzers in `FrostAnalysisConfig`, replacing old implementations and adding Army analysis.
  - Adjusted scoring weights for improved accuracy.
- Type/Import Maintenance:
  - Updated type hints and imports to support new analysis logic. [[1]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L4-R11) [[2]](diffhunk://#diff-920ed46955bc2a9d634e91605baab3698d8ce73939306f85687ac6c402eab36cL1-R3) [[3]](diffhunk://#diff-920ed46955bc2a9d634e91605baab3698d8ce73939306f85687ac6c402eab36cR18-R19) [[4]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdR27)