### PR TITLE
#69 scoring fixes

### DIFF
--- a/frontend/src/SoulReaperAnalysis.jsx
+++ b/frontend/src/SoulReaperAnalysis.jsx
@@ -13,15 +13,15 @@ export const SoulReaperAnalysis = ({ soulReaper }) => {
     )
   }
 
-  const efficiency = (soulReaper.execute_phase_casts / Math.max(1, soulReaper.max_possible_casts)) * 100
-  const efficiencyColor = efficiency >= 90 ? "green" : efficiency >= 75 ? "yellow" : "red"
-  const efficiencyIcon = efficiency >= 90 ? Check : efficiency >= 75 ? Warning : X
-  
-  const firstCastColor = soulReaper.first_cast_delay !== null 
-    ? (soulReaper.first_cast_delay <= 2 ? "green" : "yellow") 
+  const efficiency = (soulReaper.execute_window_hits / Math.max(1, soulReaper.max_possible_hits)) * 100
+  const efficiencyColor = efficiency >= 80 ? "green" : efficiency >= 60 ? "yellow" : "red"
+  const efficiencyIcon = efficiency >= 80 ? Check : efficiency >= 60 ? Warning : X
+
+  const firstHitColor = soulReaper.first_hit_delay !== null
+    ? (soulReaper.first_hit_delay <= 3 ? "green" : "yellow")
     : "red"
-  const firstCastIcon = soulReaper.first_cast_delay !== null 
-    ? (soulReaper.first_cast_delay <= 2 ? Check : Warning) 
+  const firstHitIcon = soulReaper.first_hit_delay !== null
+    ? (soulReaper.first_hit_delay <= 3 ? Check : Warning)
     : X
 
   return (
@@ -38,27 +38,27 @@ export const SoulReaperAnalysis = ({ soulReaper }) => {
       <div>
         {efficiencyIcon}
         <span>
-          Soul Reaper casts: {hl(soulReaper.execute_phase_casts)} of {hl(soulReaper.max_possible_casts)} possible
+          Soul Reaper hits in execute window: {hl(soulReaper.execute_window_hits)} of {hl(soulReaper.max_possible_hits)} possible
           {" "}(<span className={efficiencyColor}>{efficiency.toFixed(1)}%</span> efficiency)
         </span>
       </div>
-      {soulReaper.first_cast_delay !== null ? (
+      {soulReaper.first_hit_delay !== null ? (
         <div>
-          {firstCastIcon}
+          {firstHitIcon}
           <span>
-            First cast delay: <span className={firstCastColor}>{soulReaper.first_cast_delay.toFixed(1)}s</span>
-            {soulReaper.first_cast_delay <= 2 ? " (Good!)" : " (Should cast within 2s of 35%)"}
+            First execute hit delay: <span className={firstHitColor}>{soulReaper.first_hit_delay.toFixed(1)}s</span>
+            {soulReaper.first_hit_delay <= 3 ? " (Good!)" : " (Should hit within 3s of 35%)"}
           </span>
         </div>
       ) : (
         <div>
-          {firstCastIcon}
-          <span className="red">No Soul Reaper casts detected in execute phase!</span>
+          {firstHitIcon}
+          <span className="red">No Soul Reaper hits detected in execute window!</span>
         </div>
       )}
       <div>
         {Info}
-        <span>Total Soul Reaper casts: {hl(soulReaper.total_casts)}</span>
+        <span>Total Soul Reaper hits: {hl(soulReaper.total_hits)}</span>
       </div>
     </div>
   )


### PR DESCRIPTION
This pull request refactors the Soul Reaper analysis logic and adjusts the scoring and weighting for Unholy specialization analyzers. The main improvements include switching from tracking Soul Reaper casts to tracking actual hits, updating the efficiency and scoring logic accordingly, and rebalancing several score thresholds and weights for a more accurate assessment. The frontend has also been updated to reflect these backend changes, providing clearer feedback to users.

**Soul Reaper Analysis Refactor:**
- Switched from tracking Soul Reaper casts to tracking actual Soul Reaper hits on the boss, ensuring more accurate analysis of execute phase performance. The logic now identifies the boss by highest max HP, tracks hits in the execute window, and calculates efficiency and bonus for quick hits. [[1]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L1362-R1407) [[2]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L1396-R1487) [[3]](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L2247-R2288) [[4]](diffhunk://#diff-13ed1091766b0231d3bdb2229e43ab7645e1cde0586f25a5fb5fe952c6e516cbL16-R24) [[5]](diffhunk://#diff-13ed1091766b0231d3bdb2229e43ab7645e1cde0586f25a5fb5fe952c6e516cbL41-R61) [[6]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1316-R1328)

**Unholy Analyzer Scoring and Weighting Adjustments:**
- Reduced the "good" uptime thresholds for Dark Transformation and Death and Decay, making the requirements less strict. [[1]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL128-R128) [[2]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL805-R817)
- Rebalanced score weights for Gargoyle, Dark Transformation, Death and Decay, and Festering Strike analyzers to better reflect their relative importance. [[1]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1221-R1233) [[2]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1233-R1253) [[3]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL1269-R1281)

**Buff Synergy Improvements:**
- Added logic to double the scoring weight of buffs (such as trinkets, potion, Berserking, Fallen Crusader, Unholy Frenzy) when Bloodlust is active during key cooldowns (Dark Transformation and Gargoyle), rewarding better synergy. [[1]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdR360-R380) [[2]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdL387-R393) [[3]](diffhunk://#diff-79ccd7707f7da4c866fba0ca0d06a69d03d313774476a8cb57be5914f20d3cfdR668-R696)

**Frontend Updates:**
- Updated the Soul Reaper analysis UI to display "hits" instead of "casts," adjusted efficiency and timing thresholds, and improved feedback messages for users. [[1]](diffhunk://#diff-13ed1091766b0231d3bdb2229e43ab7645e1cde0586f25a5fb5fe952c6e516cbL16-R24) [[2]](diffhunk://#diff-13ed1091766b0231d3bdb2229e43ab7645e1cde0586f25a5fb5fe952c6e516cbL41-R61)

These changes collectively improve the accuracy and clarity of performance analysis for Unholy specialization, especially regarding Soul Reaper usage and buff synergy.