### PR TITLE
#83 Fixed frost and unholy blood tap rune issue

### DIFF
--- a/backend/src/analysis/core_analysis.py
+++ b/backend/src/analysis/core_analysis.py
@@ -802,7 +802,18 @@ class RuneTracker(BaseAnalyzer):
                 break
 
         # Refresh the cooldown of one of the runes
-        for i in range(2):
+        # Detect spec based on starting runes: Frost starts with death runes at indices 0-1
+        is_frost_spec = self.runes[0].type == "Death" and self.runes[1].type == "Death"
+
+        # Priority depends on spec:
+        # Unholy: Blood (0-1) > Frost (2-3) > Unholy (4-5)
+        # Frost: Unholy (4-5) > Frost (2-3) > Death/Blood (0-1)
+        if is_frost_spec:
+            rune_priority_indices = [4, 5, 2, 3, 0, 1]
+        else:  # Unholy or default
+            rune_priority_indices = [0, 1, 2, 3, 4, 5]
+
+        for i in rune_priority_indices:
             if not self.runes[i].can_spend(timestamp):
                 self.runes[i].refresh(timestamp)
                 break


### PR DESCRIPTION
This pull request updates the rune refresh logic in the `blood_tap` method to account for different Death Knight specializations by prioritizing rune refresh order based on the detected spec. The change improves accuracy when simulating rune behavior for Frost and Unholy specs.

Rune refresh logic improvements:

* [`backend/src/analysis/core_analysis.py`](diffhunk://#diff-203e3b46d197ebf1a50b5bd8389ce7921b69b177b63ba8ec3555ee6986251a71L805-R816): Added detection of Frost specialization by checking starting rune types, and updated the rune refresh priority order accordingly—Frost spec now prioritizes Unholy runes, while Unholy (and default) prioritizes Blood runes.